### PR TITLE
Use shared nanoFramework composite actions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup nanoFramework
-        uses: nanoframework/nanobuild@v1
+        uses: CoryCharlton/nanobuild@fix/support-vs2026
         with:
           gitHubAuth: ${{ github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Setup nanoFramework
         uses: nanoframework/nanobuild@v1
+        with:
+          gitHubAuth: ${{ github.token }}
 
       - name: Update nanoclr
         run: dotnet tool update -g nanoclr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
     name: GitHub Actions Test
     runs-on: windows-latest
     env:
-      BUILD_CONFIGURATION: 'Release'
       GITHUB_TOKEN: ${{ github.token }}
       SOLUTION_FOLDER: './solution/'
       SOLUTION: 'VsTestAction.sln'
@@ -61,30 +60,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup nanoFramework
-        # Pinned to the merge commit of nanoframework/nanobuild#4 (VS2026 support)
-        # until a tagged release is available; revert to @v1 once released.
-        uses: nanoframework/nanobuild@7c31aa93121b2f6fc97b3ce74655cc48b2c2c505
-        with:
-          gitHubAuth: ${{ github.token }}
-
-      - name: Update nanoclr
-        run: dotnet tool update -g nanoclr
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v3
-        with:
-          msbuild-architecture: x64
-
-      - name: Setup NuGet
-        uses: nuget/setup-nuget@v4
-
-      - name: Install dependencies
-        run: nuget restore ${{ env.SOLUTION_FOLDER }}${{ env.SOLUTION }}
+        # Temporarily pointed at the composites branch for validation; flip to
+        # @master once CCSWE-nanoFramework/actions-nanoframework#1 merges.
+        uses: CCSWE-nanoFramework/actions-nanoframework/setup-nanoframework@feature/composite-actions
 
       - name: Build solution
-        run:
-          msbuild ${{ env.SOLUTION_FOLDER }}${{ env.SOLUTION }}
-          /p:Configuration=${{ env.BUILD_CONFIGURATION }}
+        uses: CCSWE-nanoFramework/actions-nanoframework/build-nanoframework@feature/composite-actions
+        with:
+          solution: ${{ env.SOLUTION_FOLDER }}${{ env.SOLUTION }}
 
       - name: Test Local Action
         id: test-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup nanoFramework
-        uses: CoryCharlton/nanobuild@fix/support-vs2026
+        # Pinned to the merge commit of nanoframework/nanobuild#4 (VS2026 support)
+        # until a tagged release is available; revert to @v1 once released.
+        uses: nanoframework/nanobuild@7c31aa93121b2f6fc97b3ce74655cc48b2c2c505
         with:
           gitHubAuth: ${{ github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup nanoFramework
-        # Temporarily pointed at the composites branch for validation; flip to
-        # @master once CCSWE-nanoFramework/actions-nanoframework#1 merges.
-        uses: CCSWE-nanoFramework/actions-nanoframework/setup-nanoframework@feature/composite-actions
+        uses: CCSWE-nanoFramework/actions-nanoframework/setup-nanoframework@master
 
       - name: Build solution
-        uses: CCSWE-nanoFramework/actions-nanoframework/build-nanoframework@feature/composite-actions
+        uses: CCSWE-nanoFramework/actions-nanoframework/build-nanoframework@master
         with:
           solution: ${{ env.SOLUTION_FOLDER }}${{ env.SOLUTION }}
 


### PR DESCRIPTION
Replaces the inline nanoFramework toolchain in the `test-action` job with the shared `setup-nanoframework` and `build-nanoframework` composite actions from `actions-nanoframework`, removing the duplicated `nanobuild` SHA pin from this repo. This also fixes CI on the VS2026 runner (the pin lives in the composite now).

Depends on **CCSWE-nanoFramework/actions-nanoframework#1** (adds the composites).

## Status
- Validated green on the VS2026 `windows-latest` runner with the composites referenced at `@feature/composite-actions`.
- **Before merge:** flip the two `uses:` refs in `ci.yml` from `@feature/composite-actions` to `@master` once actions-nanoframework#1 merges.

## History
Earlier commits on this branch added an inline `nanobuild` SHA pin + `gitHubAuth`; those are superseded by the composite (which owns the pin and always passes the token).