### PR TITLE
DO NOT MERGE — validate nanobuild @v1 swap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup nanoFramework
-        uses: CCSWE-nanoFramework/actions-nanoframework/setup-nanoframework@master
+        uses: CCSWE-nanoFramework/actions-nanoframework/setup-nanoframework@chore/nanobuild-v1
 
       - name: Build solution
         uses: CCSWE-nanoFramework/actions-nanoframework/build-nanoframework@master


### PR DESCRIPTION
Temporary PR to run CI against `setup-nanoframework@chore/nanobuild-v1` (actions-nanoframework#2). Will be closed once green.