### PR TITLE
Add tag-driven release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Two-dot shape: matches v1.0.13 and v1.0.13-beta; excludes the bare
+      # major tag `v1` (no dots) so moving it does not re-trigger this workflow.
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, verify dist, and publish release
+    runs-on: ubuntu-latest
+    outputs:
+      major: ${{ steps.major.outputs.major }}
+      prerelease: ${{ steps.major.outputs.prerelease }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check format
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run ci-test
+
+      - name: Build dist/
+        run: npm run bundle
+
+      # Mirrors check-dist.yml: fail if the committed dist/ is stale so a tag
+      # never ships out-of-date transpiled code.
+      - name: Verify dist/ is in sync
+        run: |
+          if [ ! -d dist/ ]; then
+            echo "Expected dist/ directory does not exist."
+            ls -la ./
+            exit 1
+          fi
+          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+            echo "Committed dist/ is out of date with src/. Run 'npm run bundle' and commit before tagging."
+            git diff --ignore-space-at-eol --text dist/
+            exit 1
+          fi
+
+      - name: Compute major version and prerelease flag
+        id: major
+        run: |
+          ref="${GITHUB_REF_NAME}"          # e.g. v1.0.13 or v1.0.13-beta.1
+          echo "major=${ref%%.*}" >> "$GITHUB_OUTPUT"   # -> v1
+          if [[ "${ref}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=("${GITHUB_REF_NAME}" --generate-notes --title "${GITHUB_REF_NAME}")
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}"
+
+  update-major-version:
+    name: Move major tag (${{ needs.release.outputs.major }})
+    needs: release
+    # Never move the major tag to a prerelease.
+    if: ${{ needs.release.outputs.prerelease == 'false' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/update-main-version.yml
+    with:
+      target: ${{ github.ref_name }}
+      major_version: ${{ needs.release.outputs.major }}
+    secrets: inherit

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,7 +1,5 @@
 name: Update Main Version
-run-name:
-  Move ${{ github.event.inputs.major_version }} to ${{
-  github.event.inputs.target }}
+run-name: Move ${{ inputs.major_version }} to ${{ inputs.target }}
 
 on:
   workflow_dispatch:
@@ -14,6 +12,21 @@ on:
         description: The major version to update
         options:
           - v1
+  workflow_call:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+        type: string
+      major_version:
+        # workflow_call cannot use type: choice; the caller passes the major
+        # derived from the release tag (e.g. v1, and v2 once it exists).
+        description: The major version to update
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   tag:
@@ -30,8 +43,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Tag new target
-        run:
-          git tag -f ${{ github.event.inputs.major_version }} ${{
-          github.event.inputs.target }}
+        run: git tag -f ${{ inputs.major_version }} ${{ inputs.target }}
       - name: Push new tag
-        run: git push origin ${{ github.event.inputs.major_version }} --force
+        run: git push origin ${{ inputs.major_version }} --force

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ With a runsettings file, parallel execution, and code coverage:
 
 Releases are tag-driven. To cut a release:
 
-1. Make sure `master` is green and `dist/` is committed and up to date (`npm run
-   bundle` produces no diff — CI enforces this).
+1. Make sure `master` is green and `dist/` is committed and up to date
+   (`npm run bundle` produces no diff — CI enforces this).
 2. Create and push a `vMAJOR.MINOR.PATCH` tag:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -70,3 +70,30 @@ With a runsettings file, parallel execution, and code coverage:
     artifactName: 'unit_test_results'
     artifactRetentionDays: 7
 ```
+
+## Releasing
+
+Releases are tag-driven. To cut a release:
+
+1. Make sure `master` is green and `dist/` is committed and up to date (`npm run
+   bundle` produces no diff — CI enforces this).
+2. Create and push a `vMAJOR.MINOR.PATCH` tag:
+
+   ```bash
+   git tag v1.0.13
+   git push origin v1.0.13
+   ```
+
+The [`Release`](.github/workflows/release.yml) workflow then re-runs
+format/lint/test, re-verifies the committed `dist/`, creates a GitHub Release
+with auto-generated (categorized) notes, and moves the major tag (`v1`) to the
+new release.
+
+For a prerelease, include a hyphen (e.g. `v1.1.0-beta.1`): the release is marked
+**pre-release** and the major `v1` tag is **not** moved.
+
+Consumers keep referencing the major tag:
+
+```yaml
+- uses: CCSWE-nanoFramework/vstest-nanoframework@v1
+```


### PR DESCRIPTION
Adds release automation for this action (modeled on a tag-driven `release.yml`, adapted for a node action — no dotnet/NBGV, no per-RID assets).

## What it does
Pushing a `vMAJOR.MINOR.PATCH` tag triggers `.github/workflows/release.yml`, which:
- gates on `npm ci` + format/lint/test (`ci-test`) and a **dist/ sync check** (rebuilds and fails if committed `dist/` is stale);
- creates a GitHub Release for the tag with auto-generated, **categorized** notes (`--generate-notes` + `.github/release.yml`);
- **moves the major tag** (`v1`) by calling `update-main-version.yml` as a reusable workflow.

Prerelease tags (with a hyphen, e.g. `v1.1.0-beta.1`) are marked pre-release and do **not** move the major tag.

## Changes
- `.github/workflows/release.yml` — new.
- `.github/workflows/update-main-version.yml` — add `workflow_call` (alongside `workflow_dispatch`), `permissions: contents: write`, switch body to `inputs.*`.
- `.github/release.yml` — categorize changelog (Features / Bug Fixes / Dependencies / Other; Dependabot PRs use the `dependencies` label).
- README — Releasing section.

## Notes
- No recursion: the `v*.*.*` glob excludes the bare `v1` tag, and `GITHUB_TOKEN` pushes don't trigger workflows.
- Release gate is ubuntu-only (format/lint/test + dist); the heavy windows e2e already gates `master`.

Tested: actionlint clean; YAML validated. Full end-to-end (cutting a real prerelease tag) can be run after merge.